### PR TITLE
Removido bug travar leitura

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -31,7 +31,10 @@ void Core::joy_thread(){
 }
 
 void Core::com_thread(){
-    //! Caso o destino seja o VSS-Simulator o trecho de código já está bem definido
+    //Transmission transmission;
+    JoyAxis left;
+
+     //! Caso o destino seja o VSS-Simulator o trecho de código já está bem definido
     if(type == SIMULATOR){
         //! A interface de comunicação com o VSS-Simulator é criada 
         interface.createSendCommandsTeam1(&global_commands, ip);
@@ -69,10 +72,15 @@ void Core::com_thread(){
             usleep(1000);
         }
     }else{
-        //! Caso o destino seja robôs reais
-        cerr << "You must implement your own communication..." << endl;
-        //! O necessário adicionar o módulo de comunicação referente a plataforma utilizada
-        //! Deve-se utilizar a leitura do analógico da mesma forma apresentada quando o destino é o VSS-Simulator 
+
+        while(true){
+            left = rc_joy.get_axis_left();
+            // left.show();
+
+            //! your own transmission module here
+            
+            usleep(33000);
+        }
     }
 }
 

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -31,7 +31,7 @@ void Core::joy_thread(){
 }
 
 void Core::com_thread(){
-    //Transmission transmission;
+
     JoyAxis left;
 
      //! Caso o destino seja o VSS-Simulator o trecho de código já está bem definido
@@ -77,7 +77,7 @@ void Core::com_thread(){
             left = rc_joy.get_axis_left();
             // left.show();
             //! cout << left[X] << " " << left[Y] << end;
-            
+
             //! your own transmission module here
             
             usleep(33000);

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -76,7 +76,8 @@ void Core::com_thread(){
         while(true){
             left = rc_joy.get_axis_left();
             // left.show();
-
+            //! cout << left[X] << " " << left[Y] << end;
+            
             //! your own transmission module here
             
             usleep(33000);

--- a/src/core.h
+++ b/src/core.h
@@ -11,7 +11,7 @@
 
 #include "iostream"
 
-#include "VSS-Interface/cpp/interface.h"
+//#include "VSS-Interface/cpp/interface.h"
 #include "reader_control_joy.h"
 
 #include "thread"
@@ -25,7 +25,7 @@ protected:
     //! Interpretador de comandos de um joytick USB
     ReaderControlJoy rc_joy;
     //! Interface de comunicação com o VSS-Simulator
-    Interface interface;
+//    Interface interface;
     //! Ip do VSS-Simulator
     string ip;
 
@@ -39,7 +39,7 @@ protected:
     //! Valores obtidos na leitura do analógico esquerdo de um joystick
     JoyAxis left;
     //! Comandos para serem enviados ao VSS-Simulator
-    vss_command::Global_Commands global_commands;
+//    vss_command::Global_Commands global_commands;
 
 public:
     //! Construtor DEFAULT

--- a/src/core.h
+++ b/src/core.h
@@ -11,7 +11,7 @@
 
 #include "iostream"
 
-//#include "VSS-Interface/cpp/interface.h"
+#include "VSS-Interface/cpp/interface.h"
 #include "reader_control_joy.h"
 
 #include "thread"
@@ -25,7 +25,7 @@ protected:
     //! Interpretador de comandos de um joytick USB
     ReaderControlJoy rc_joy;
     //! Interface de comunicação com o VSS-Simulator
-//    Interface interface;
+    Interface interface;
     //! Ip do VSS-Simulator
     string ip;
 
@@ -39,7 +39,7 @@ protected:
     //! Valores obtidos na leitura do analógico esquerdo de um joystick
     JoyAxis left;
     //! Comandos para serem enviados ao VSS-Simulator
-//    vss_command::Global_Commands global_commands;
+    vss_command::Global_Commands global_commands;
 
 public:
     //! Construtor DEFAULT

--- a/src/reader_control_joy.cpp
+++ b/src/reader_control_joy.cpp
@@ -17,17 +17,16 @@ void ReaderControlJoy::init(){
     //! Caso um joystick esteja conectado.
     if(joystick.isFound()){
         // É criado duas threads para leitura dos valores do joystick
-        left_thread_x = new thread(bind(&ReaderControlJoy::thread_left_x, this));
-        left_thread_y = new thread(bind(&ReaderControlJoy::thread_left_y, this));
+        analog_left_thread = new thread(bind(&ReaderControlJoy::func_analog_left, this));
 
-        left_thread_x->join();
-        left_thread_y->join();
-    }
+        analog_left_thread->join();
+    } 
 }
 
-void ReaderControlJoy::thread_left_x(){
+void ReaderControlJoy::func_analog_left(){
     //! Loop contendo a leitura do eixo X do analógico esquerdo
     while(true){
+
         JoystickEvent event;
         joystick.sample(&event);
         //! Caso o evento enviado pelo joystick seja uma nova leitura do eixo X do analógico esquerdo
@@ -35,30 +34,19 @@ void ReaderControlJoy::thread_left_x(){
             //! Lê o valor obtido
             left.axis[X] = event.value;
             
-            //! Normaliza o valor para algo entre 0 e 100
-            left.axis[X] = left.axis[X]/MAX_VAL * 100.0;
-
-            //! ATENCÃO: A Leitura sofre com perda de informação, por isso as vezes o valor trava. TODO: Resolver.
+            //! Normaliza o valor para algo entre 0 e 200
+            left.axis[X] = left.axis[X]/MAX_VAL * 200.0;
         }
-        usleep(delay);
-    }
-}
 
-void ReaderControlJoy::thread_left_y(){
-    //! Loop contendo a leitura do eixo X do analógico esquerdo
-    while(true){
-        JoystickEvent event;
-        joystick.sample(&event);
-        //! Caso o evento enviado pelo joystick seja uma nova leitura do eixo Y do analógico esquerdo
+        //! Leitura de evento caso seja do eixo Y no analogico esquerdo
         if (event.isAxis() && event.number == 1){
-            //! Lê o valor obtido
+             //! Lê o valor obtido
             left.axis[Y] = event.value;
             
-            //! Normaliza o valor para algo entre 0 e 100
-            left.axis[Y] = left.axis[Y]/MAX_VAL * -100.0;
-
-            //! ATENCÃO: A Leitura sofre com perda de informação, por isso as vezes o valor trava. TODO: Resolver.
+            //! Normaliza o valor para algo entre 0 e 200
+            left.axis[Y] = left.axis[Y]/MAX_VAL * -200.0;
         }
+        
         usleep(delay);
     }
 }

--- a/src/reader_control_joy.cpp
+++ b/src/reader_control_joy.cpp
@@ -10,7 +10,8 @@
 #include "reader_control_joy.h"
 
 // verify your joystick number
-ReaderControlJoy::ReaderControlJoy() : joystick(0) {
+ReaderControlJoy::ReaderControlJoy() {
+    joystick = Joystick(0);
     delay = 500;
 };
 

--- a/src/reader_control_joy.cpp
+++ b/src/reader_control_joy.cpp
@@ -9,7 +9,8 @@
 
 #include "reader_control_joy.h"
 
-ReaderControlJoy::ReaderControlJoy(){
+// verify your joystick number
+ReaderControlJoy::ReaderControlJoy() : joystick(0) {
     delay = 500;
 };
 

--- a/src/reader_control_joy.h
+++ b/src/reader_control_joy.h
@@ -17,7 +17,7 @@
 #include "commons.h"
 #include "joystick/joystick.hh"
 
-//! Essa classe é responsável poder interpretar os valores obtidos de qualquer joystick usb 
+//! Essa classe é responsável por interpretar os valores obtidos de qualquer joystick usb 
 class ReaderControlJoy{
 protected:
     //! Classe de acesso a um jostick
@@ -28,19 +28,18 @@ protected:
     int delay;
 
     //! Threads de leitura do eixo X e Y do analógico esquerdo
-    thread *left_thread_x, *left_thread_y;
+    thread *analog_left_thread;
 
 public:
-    //! Construcot DEFAULT
+    //! Construtor DEFAULT
     ReaderControlJoy();
 
     //! Método responsável por inicializar o interpretador 
     void init();
 
-    //! Método reponsável por efetuar as leituras do eixo X do analógico esquerdo
-    void thread_left_x();
-    //! Método responsável por efetur as leituras do eixo Y do analógico direito
-    void thread_left_y();
+    //! Método reponsável por efetuar as leituras do analógico esquerdo
+    void func_analog_left();
+    
     //! Método responsável por retornar as leituras do analógico esquerdo
     JoyAxis get_axis_left();
     


### PR DESCRIPTION
- Uni as duas threads que realizavam a leitura dos eixos do mesmo analógico em uma thread;
- Defini um pouco do escopo para usar o joystick com transmissão real;
- No construtor da classe reader_control_joy chamei o construtor da classe Joystick passando como parâmetro o número do joystick, uma vez que este pode variar de acordo com o pc